### PR TITLE
Fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ I am an independent educator and open-source enthusiast who creates meaningful p
 
 You, all my `Stargazers`, are making it work. This is because of you. A BIG THANK YOU to all of you ❤️.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tapascript/40-days-of-javascript&type=Date)](https://www.star-history.com/#tapascript/40-days-of-javascript&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=tapascript/40-days-of-javascript&type=Date)](https://star-history.dera.page/#tapascript/40-days-of-javascript&type=Date)
 
 ## 🥇 Join the Discord Server
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the original service is affected by GitHub's stargazer API restrictions. This change updates the chart to use an alternative service that works reliably and requires no API token, so the chart renders correctly again. Please take a look and merge.